### PR TITLE
Fix some issues with unforeseen CSS declarations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - '2.7'
-  - '3.5'
   - '3.6'
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - '2.7'
   - '3.5'
   - '3.6'
 install:

--- a/docs/development/scripts/python_lib_wcag.py
+++ b/docs/development/scripts/python_lib_wcag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 from wcag_zoo.validators.tarsier import Tarsier
 
 my_html = b"<html><head><body><h2>This is wrong, it should be h1"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "webcolors",
         "click",
         "xtermcolor",
+        "six",
     ],
 
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 envlist =
-    {py35,py36}-zoo-{windows,linux}
+    {py27,py35,py36}-zoo-{windows,linux}
     flake8
     scripts-linux
     docs-linux

--- a/wcag_zoo/testrunner.py
+++ b/wcag_zoo/testrunner.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import click
 from lxml import etree
 from ast import literal_eval

--- a/wcag_zoo/utils.py
+++ b/wcag_zoo/utils.py
@@ -10,6 +10,8 @@ from premailer import Premailer
 # From Premailer
 import cssutils
 import re
+from six import u
+
 cssutils.log.setLevel(logging.CRITICAL)
 _element_selector_regex = re.compile(r'(^|\s)\w')
 FILTER_PSEUDOSELECTORS = [':last-child', ':first-child', 'nth-child']
@@ -66,9 +68,9 @@ class Premoler(Premailer):
 
         def format_css_property(prop):
             if self.strip_important or prop.priority != 'important':
-                return '{0}:{1}'.format(prop.name, prop.value)
+                return u('{0}:{1}').format(prop.name, prop.value)
             else:
-                return '{0}:{1} !important'.format(prop.name, prop.value)
+                return u('{0}:{1} !important').format(prop.name, prop.value)
 
         def join_css_properties(properties):
             """ Accepts a list of cssutils Property objects and returns

--- a/wcag_zoo/utils.py
+++ b/wcag_zoo/utils.py
@@ -199,7 +199,7 @@ def get_applicable_styles(node):
 
         styles.append(dict([
             tuple(
-                s.strip().split(':')
+                s.strip().split(':', 1)
             )
             for s in style.split(';')
         ])


### PR DESCRIPTION
Declarations including colons would not work at all, and declarations with non-ascii characters wouldn't work on Python 2.