### PR TITLE
Be okay with colons in style declarations.

### DIFF
--- a/wcag_zoo/utils.py
+++ b/wcag_zoo/utils.py
@@ -197,7 +197,7 @@ def get_applicable_styles(node):
 
         styles.append(dict([
             tuple(
-                s.strip().split(':')
+                s.strip().split(':', 1)
             )
             for s in style.split(';')
         ])


### PR DESCRIPTION
This is necessary for any case where you have an absolute URL as a
background image, or a colon in a content: declaration, for instance.

Of course, I am biased towards acceptance of colons.