### PR TITLE
Fix calculation of foreground colours.

### DIFF
--- a/tests/html/molerat-color-contrast.html
+++ b/tests/html/molerat-color-contrast.html
@@ -16,6 +16,15 @@
                 color: OldLace;
                 background-color: Linen;
             }
+            .black {
+                background-color: rgb(0,0,0);
+            }
+            .very-light {
+                color: rgba(255,255,255, 0.9);
+            }
+            .very-dark {
+                color: rgba(255,255,255, 0.1);
+            }
         </style>
     </head>
     <body>
@@ -25,10 +34,20 @@
         </div>
         <p class="habdashery" data-wcag-failure-code="molerat-1">
             This is hard to read.
-            <span style="color:#00000" data-wcag="success">
+            <span style="color:#000000" data-wcag="success">
                 This is better!
             </span>
         </p>
+        <div class="black very-dark">
+            <p data-wcag-failure-code="molerat-1">
+                This is hard to read.
+            </p>
+        </div>
+        <div class="black very-light">
+            <p data-wcag="success">
+                This is easy to read.
+            </p>
+        </div>
         </div>
     </body>
 </html>

--- a/wcag_zoo/validators/molerat.py
+++ b/wcag_zoo/validators/molerat.py
@@ -89,7 +89,7 @@ def generate_opaque_color(color_stack):
     for c in color_stack[::-1]:
         if c[3] == 0:
             continue
-        colors.append([D(p) for p in c])
+        colors.insert(0, [D(p) for p in c])
         if c[3] == 1.0:
             break
 
@@ -100,10 +100,11 @@ def generate_opaque_color(color_stack):
             # Skip transparent colors
             continue
         da = 1 - a
-        alpha = alpha + a * da
-        red = (red * D('0.25') + r * a * da) / alpha
-        green = (green * D('0.25') + g * a * da) / alpha
-        blue = (blue * D('0.25') + b * a * da) / alpha
+        old_alpha = alpha
+        alpha = a + old_alpha * da
+        red = (r * D(a) + red * old_alpha * da) / alpha
+        green = (g * D(a) + green * old_alpha * da) / alpha
+        blue = (b * D(a) + blue * old_alpha * da) / alpha
 
     return [int(red), int(green), int(blue)]
 

--- a/wcag_zoo/validators/molerat.py
+++ b/wcag_zoo/validators/molerat.py
@@ -87,9 +87,9 @@ def generate_opaque_color(color_stack):
     colors = []
     # Take colors back off the stack until we get one with an alpha of 1.0
     for c in color_stack[::-1]:
-        if int(c[3]) == 0:
+        if c[3] == 0:
             continue
-        colors.append(c)
+        colors.append([D(p) for p in c])
         if c[3] == 1.0:
             break
 
@@ -223,7 +223,7 @@ class Molerat(WCAGCommand):
 
         font_size = calculate_font_size(fonts)
         font_is_bold = is_font_bold(fonts)
-        foreground = generate_opaque_color(colors)
+        foreground = generate_opaque_color(backgrounds + [colors[-1]])
         background = generate_opaque_color(backgrounds)
         ratio = calculate_luminocity_ratio(foreground, background)
 

--- a/wcag_zoo/validators/molerat.py
+++ b/wcag_zoo/validators/molerat.py
@@ -31,13 +31,15 @@ TECHNIQUE = {
 }
 
 
-def normalise_color(color):
+def normalise_color(color, inherited_color):
     rgba_color = None
     color = color.split("!", 1)[0].strip()  # remove any '!important' declarations
     color = color.strip(";").strip("}")  # Dang minimisers
 
-    if "transparent" in color or "inherit" in color:
-        rgba_color = [0, 0, 0, 0.0]
+    if "inherit" in color:
+        rgba_color = inherited_color
+    if "transparent" in color:
+        rgba_color = [0, 0, 0, 0]
     elif color.startswith('rgb('):
         rgba_color = list(map(int, color.split('(')[1].split(')')[0].split(', ')))
     elif color.startswith('rgba('):
@@ -213,9 +215,9 @@ class Molerat(WCAGCommand):
 
         for styles in get_applicable_styles(node):
             if "color" in styles.keys():
-                colors.append(normalise_color(styles['color']))
+                colors.append(normalise_color(styles['color'], colors[-1]))
             if "background-color" in styles.keys():
-                backgrounds.append(normalise_color(styles['background-color']))
+                backgrounds.append(normalise_color(styles['background-color'], backgrounds[-1]))
             font_rules = {}
             for rule in styles.keys():
                 if 'font' in rule:


### PR DESCRIPTION
This should fix #16.

There were a few things wrong here; firstly, the `color` of foreground text is not based on stacking all parent `color` attributes; it's based on stacking the single most specific `color` on top of all previous
backgrounds.

Secontly, int(0.9) is zero, so all semitransparency was being ignored.